### PR TITLE
IPFS Preload Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Terraform
+
 ## Terraform Setup
 
 ```
@@ -29,3 +31,7 @@ git clone https://github.com/ceramicnetwork/js-ceramic.git
 npm run bootstrap
 npm run build
 ```
+
+# NixOS
+
+The `ipfs-preload` is a NixOS image. Nix configurations live in [./nix](./nix) and can be updated manually over SSH.

--- a/ipfs-clay-1.tf
+++ b/ipfs-clay-1.tf
@@ -26,38 +26,6 @@ resource "digitalocean_droplet" "ipfs_clay_1" {
     }
 }
 
-resource "digitalocean_certificate" "cert" {
-  name    = "ceramicnode"
-  type    = "lets_encrypt"
-  domains = ["ceramic.geoweb.network"]
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "digitalocean_loadbalancer" "public" {
-  name   = "ceramic-lb"
-  region = "sfo3"
-
-  forwarding_rule {
-    entry_port     = 443
-    entry_protocol = "https"
-
-    target_port     = 7007
-    target_protocol = "http"
-
-    certificate_name = digitalocean_certificate.cert.name
-  }
-
-  healthcheck {
-    port     = 22
-    protocol = "tcp"
-  }
-
-  droplet_ids = [digitalocean_droplet.ipfs_clay_1.id]
-}
-
 resource "digitalocean_domain" "ipfs_clay_1" {
   name       = "ipfs-clay-1.ceramic.geoweb.network"
   ip_address = digitalocean_droplet.ipfs_clay_1.ipv4_address

--- a/ipfs-preload.tf
+++ b/ipfs-preload.tf
@@ -17,6 +17,12 @@ resource "digitalocean_droplet" "ipfs-preload" {
     }
 }
 
+resource "digitalocean_domain" "ipfs_preload" {
+  name       = "preload.ipfs.geoweb.network"
+  ip_address = digitalocean_droplet.ipfs-preload.ipv4_address
+}
+
+
 resource "digitalocean_firewall" "ipfs_firewall" {
   name = "ipfs"
 
@@ -25,6 +31,12 @@ resource "digitalocean_firewall" "ipfs_firewall" {
   inbound_rule {
     protocol         = "tcp"
     port_range       = "22"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "80"
     source_addresses = ["0.0.0.0/0", "::/0"]
   }
 

--- a/ipfs-preload.tf
+++ b/ipfs-preload.tf
@@ -36,6 +36,12 @@ resource "digitalocean_firewall" "ipfs_firewall" {
 
   inbound_rule {
     protocol         = "tcp"
+    port_range       = "4001"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  inbound_rule {
+    protocol         = "tcp"
     port_range       = "80"
     source_addresses = ["0.0.0.0/0", "::/0"]
   }

--- a/ipfs-preload.tf
+++ b/ipfs-preload.tf
@@ -1,0 +1,47 @@
+resource "digitalocean_droplet" "ipfs-preload" {
+    image = 78848161
+    name = "ipfs-preload"
+    region = "sfo3"
+    size = "s-1vcpu-1gb"
+    private_networking = true
+    backups = false
+    ssh_keys = [
+      data.digitalocean_ssh_key.terraform.id
+    ]
+    connection {
+        host = self.ipv4_address
+        user = "root"
+        type = "ssh"
+        private_key = file(var.pvt_key)
+        timeout = "2m"
+    }
+}
+
+resource "digitalocean_firewall" "ipfs_firewall" {
+  name = "ipfs"
+
+  droplet_ids = [digitalocean_droplet.ipfs-preload.id]
+
+  inbound_rule {
+    protocol         = "tcp"
+    port_range       = "22"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  inbound_rule {
+    protocol         = "icmp"
+    source_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "tcp"
+    port_range            =  "1-65535" 
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+
+  outbound_rule {
+    protocol              = "udp"
+    port_range            =  "1-65535" 
+    destination_addresses = ["0.0.0.0/0", "::/0"]
+  }
+}

--- a/nix/ipfs-preload.nix
+++ b/nix/ipfs-preload.nix
@@ -9,7 +9,7 @@ in {
     environment.systemPackages = [ pkgs.ipfs_0_8 ];
 
     networking.hostName = "ipfs-preload";
-    networking.firewall.allowedTCPPorts = [ 80 ];
+    networking.firewall.allowedTCPPorts = [ 80 4001 ];
     
     # Users
     users.users.ipfs = {

--- a/nix/ipfs-preload.nix
+++ b/nix/ipfs-preload.nix
@@ -1,0 +1,40 @@
+{ modulesPath, lib, ... }:
+let
+    pkgs = import <nixos-20.09> { };
+in {
+    imports = lib.optional (builtins.pathExists ./do-userdata.nix) ./do-userdata.nix ++ [
+        (modulesPath + "/virtualisation/digital-ocean-config.nix")
+    ];
+
+    environment.systemPackages = [ pkgs.ipfs_0_8 ];
+
+    networking.hostName = "ipfs-preload";
+    
+    # Users
+    users.users.ipfs = {
+        isNormalUser = true;
+    };
+
+    # Services
+    systemd.services = {
+        ipfs = {
+            description = "IPFS Daemon";
+            serviceConfig = {
+                Type = "simple";
+                User = "ipfs";
+                ExecStart = "${pkgs.ipfs_0_8}/bin/ipfs daemon";
+            };
+            wantedBy = [ "multi-user.target" ];
+        };
+    };
+
+    services.nginx = {
+        enable = true;
+        virtualHosts.default = {
+            default = true;
+            locations."/api/v0/refs" = {
+                proxyPass = "http://localhost:5001/api/v0/refs";
+            };
+        };
+    };
+}

--- a/nix/ipfs-preload.nix
+++ b/nix/ipfs-preload.nix
@@ -9,6 +9,7 @@ in {
     environment.systemPackages = [ pkgs.ipfs_0_8 ];
 
     networking.hostName = "ipfs-preload";
+    networking.firewall.allowedTCPPorts = [ 80 ];
     
     # Users
     users.users.ipfs = {


### PR DESCRIPTION
Adds a new NixOS droplet that runs an IPFS node with the `/refs` API proxied through Nginx.